### PR TITLE
Analytics pane support example

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,13 +19,13 @@
       "fileMatch": [
         "/pbiviz.json"
       ],
-      "url": "./.api/v2.3.0/schema.pbiviz.json"
+      "url": "./.api/v2.5.0/schema.pbiviz.json"
     },
     {
       "fileMatch": [
         "/capabilities.json"
       ],
-      "url": "./.api/v2.3.0/schema.capabilities.json"
+      "url": "./.api/v2.5.0/schema.capabilities.json"
     }
   ]
 }

--- a/capabilities.json
+++ b/capabilities.json
@@ -117,8 +117,8 @@
                         }
                     }
                 },
-                "showDataLable": {
-                    "displayName": "Data lable",
+                "showDataLabel": {
+                    "displayName": "Data label",
                     "type": {
                         "bool": true
                     }

--- a/capabilities.json
+++ b/capabilities.json
@@ -92,6 +92,38 @@
                     }
                 }
             }
+        },
+        "averageLine" :{
+            "displayName": "Average Line",
+            "objectCategory": 2,
+            "properties": {
+                "show": {
+                    "type": {
+                        "bool": true
+                    }
+                },
+                "displayName": {
+                    "type": {
+                        "text": true
+                    }
+                },
+                "fill": {
+                    "displayName": "Color",
+                    "type": {
+                        "fill": {
+                            "solid": {
+                                "color": true
+                            }
+                        }
+                    }
+                },
+                "showDataLable": {
+                    "displayName": "Data lable",
+                    "type": {
+                        "bool": true
+                    }
+                }
+            }
         }
     },
     "tooltips": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "visual",
-    "version": "1.3.0",
+    "version": "2.5.0",
     "scripts": {
-        "postinstall": "pbiviz update 2.3.0",
+        "postinstall": "pbiviz update 2.5.0",
         "pbiviz": "pbiviz",
         "start": "pbiviz start",
         "lint": "tslint -r \"node_modules/tslint-microsoft-contrib\"  \"+(src|test)/**/*.ts\"",
@@ -11,7 +11,7 @@
     "devDependencies": {
         "@types/d3": "3.5.36",
         "d3": "3.5.5",
-        "powerbi-visuals-tools": "2.3.0",
+        "powerbi-visuals-tools": "2.5.0",
         "tslint": "4.4.2",
         "tslint-microsoft-contrib": "4.0.0"
     }

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -4,12 +4,12 @@
     "displayName": "barChart",
     "guid": "PBI_CV_9894B302_1DFF_4A96_ABFE_BF8588197166",
     "visualClassName": "BarChart",
-    "version": "1.3.0",
+    "version": "2.5.0",
     "description": "",
     "supportUrl": "",
     "gitHubUrl": ""
   },
-  "apiVersion": "2.3.0",
+  "apiVersion": "2.5.0",
   "author": {
     "name": "",
     "email": ""

--- a/src/barChart.ts
+++ b/src/barChart.ts
@@ -622,7 +622,7 @@ module powerbi.extensibility.visual {
 
             // If plain string, just return it
             if (typeof(color) === 'string') {
-                return color
+                return color;
             }
             // Otherwise, extract string representation from Fill type object
             return color.solid.color;
@@ -631,28 +631,28 @@ module powerbi.extensibility.visual {
         private initAverageLine() {
             this.averageLine = this.svg
                 .append('g')
-                .classed('averageLine',true);
+                .classed('averageLine', true);
 
             this.averageLine.append('line')
-                .attr('id','averageLine');
+                .attr('id', 'averageLine');
 
             this.averageLine.append('text')
-                .attr('id','averageLineLabel');
+                .attr('id', 'averageLineLabel');
         }
 
-        private handleAverageLineUpdate(height:number, width:number, yScale: d3.scale.Linear<number,number>) {
+        private handleAverageLineUpdate(height: number, width: number, yScale: d3.scale.Linear<number, number>) {
             let average = this.calculateAverage();
             let fontSize = d3.min([height, width]) * BarChart.Config.xAxisFontMultiplier;
             let chosenColor = this.getColorValue(this.barChartSettings.averageLine.fill);
             // If there's no room to place lable above line, place it below
-            let lableYOffset = fontSize * ((yScale(average) > fontSize * 1.5)? -0.5 : 1.5);
+            let lableYOffset = fontSize * ((yScale(average) > fontSize * 1.5) ? -0.5 : 1.5);
 
             this.averageLine
                 .style({
                     "font-size": fontSize,
-                    "display": (this.barChartSettings.averageLine.show)? "initial" : "none",
+                    "display": (this.barChartSettings.averageLine.show) ? "initial" : "none",
                 })
-                .attr("transform", "translate(0, " + Math.round(yScale(average)) + ")")
+                .attr("transform", "translate(0, " + Math.round(yScale(average)) + ")");
             this.averageLine.select("#averageLine")
                 .style({
                     "stroke": chosenColor,
@@ -664,9 +664,9 @@ module powerbi.extensibility.visual {
                     'x2': "" + width
                 });
             this.averageLine.select("#averageLineLabel")
-                .text("Average: "+average.toFixed(2))
+                .text("Average: " + average.toFixed(2))
                 .attr("transform", "translate(0, " + lableYOffset + ")")
-                .style("fill", this.barChartSettings.averageLine.showDataLable? chosenColor: "none");
+                .style("fill", this.barChartSettings.averageLine.showDataLable ? chosenColor : "none");
         }
 
         private calculateAverage(): number {
@@ -676,11 +676,11 @@ module powerbi.extensibility.visual {
 
             let total = 0;
 
-            this.barDataPoints.forEach((value:BarChartDataPoint) => {
+            this.barDataPoints.forEach((value: BarChartDataPoint) => {
                 total += <number>value.value;
-            })
+            });
 
-            return total/this.barDataPoints.length;
+            return total / this.barDataPoints.length;
         }
     }
 }

--- a/src/barChart.ts
+++ b/src/barChart.ts
@@ -58,7 +58,7 @@ module powerbi.extensibility.visual {
             show: boolean;
             displayName: string;
             fill: string;
-            showDataLable: boolean;
+            showDataLabel: boolean;
         };
     }
 
@@ -87,7 +87,7 @@ module powerbi.extensibility.visual {
                 show: false,
                 displayName: "Average Line",
                 fill: "#888888",
-                showDataLable: false
+                showDataLabel: false
             }
         };
         let viewModel: BarChartViewModel = {
@@ -132,7 +132,7 @@ module powerbi.extensibility.visual {
                 show: getValue<boolean>(objects, 'averageLine', 'show', defaultSettings.averageLine.show),
                 displayName: getValue<string>(objects, 'averageLine', 'displayName', defaultSettings.averageLine.displayName),
                 fill: getValue<string>(objects, 'averageLine', 'fill', defaultSettings.averageLine.fill),
-                showDataLable: getValue<boolean>(objects, 'averageLine', 'showDataLable', defaultSettings.averageLine.showDataLable),
+                showDataLabel: getValue<boolean>(objects, 'averageLine', 'showDataLabel', defaultSettings.averageLine.showDataLabel),
             },
         };
 
@@ -535,7 +535,7 @@ module powerbi.extensibility.visual {
                             show: this.barChartSettings.averageLine.show,
                             displayName: this.barChartSettings.averageLine.displayName,
                             fill: this.barChartSettings.averageLine.fill,
-                            showDataLable: this.barChartSettings.averageLine.showDataLable
+                            showDataLabel: this.barChartSettings.averageLine.showDataLabel
                         },
                         selector: null
                     });
@@ -645,7 +645,7 @@ module powerbi.extensibility.visual {
             let fontSize = d3.min([height, width]) * BarChart.Config.xAxisFontMultiplier;
             let chosenColor = this.getColorValue(this.barChartSettings.averageLine.fill);
             // If there's no room to place lable above line, place it below
-            let lableYOffset = fontSize * ((yScale(average) > fontSize * 1.5) ? -0.5 : 1.5);
+            let labelYOffset = fontSize * ((yScale(average) > fontSize * 1.5) ? -0.5 : 1.5);
 
             this.averageLine
                 .style({
@@ -665,8 +665,8 @@ module powerbi.extensibility.visual {
                 });
             this.averageLine.select("#averageLineLabel")
                 .text("Average: " + average.toFixed(2))
-                .attr("transform", "translate(0, " + lableYOffset + ")")
-                .style("fill", this.barChartSettings.averageLine.showDataLable ? chosenColor : "none");
+                .attr("transform", "translate(0, " + labelYOffset + ")")
+                .style("fill", this.barChartSettings.averageLine.showDataLabel ? chosenColor : "none");
         }
 
         private calculateAverage(): number {

--- a/src/barChart.ts
+++ b/src/barChart.ts
@@ -53,6 +53,13 @@ module powerbi.extensibility.visual {
             showHelpLink: boolean;
             helpLinkColor: string;
         };
+
+        averageLine: {
+            show: boolean;
+            displayName: string;
+            fill: string;
+            showDataLable: boolean;
+        };
     }
 
     /**
@@ -75,6 +82,12 @@ module powerbi.extensibility.visual {
                 opacity: 100,
                 showHelpLink: false,
                 helpLinkColor: "#80B0E0",
+            },
+            averageLine: {
+                show: false,
+                displayName: "Average Line",
+                fill: "#888888",
+                showDataLable: false
             }
         };
         let viewModel: BarChartViewModel = {
@@ -114,6 +127,12 @@ module powerbi.extensibility.visual {
                 opacity: getValue<number>(objects, 'generalView', 'opacity', defaultSettings.generalView.opacity),
                 showHelpLink: getValue<boolean>(objects, 'generalView', 'showHelpLink', defaultSettings.generalView.showHelpLink),
                 helpLinkColor: strokeColor,
+            },
+            averageLine: {
+                show: getValue<boolean>(objects, 'averageLine', 'show', defaultSettings.averageLine.show),
+                displayName: getValue<string>(objects, 'averageLine', 'displayName', defaultSettings.averageLine.displayName),
+                fill: getValue<string>(objects, 'averageLine', 'fill', defaultSettings.averageLine.fill),
+                showDataLable: getValue<boolean>(objects, 'averageLine', 'showDataLable', defaultSettings.averageLine.showDataLable),
             },
         };
 
@@ -217,6 +236,7 @@ module powerbi.extensibility.visual {
         private isLandingPageOn: boolean;
         private LandingPageRemoved: boolean;
         private LandingPage: d3.Selection<any>;
+        private averageLine: d3.Selection<SVGElement>;
 
         private barSelection: d3.selection.Update<BarChartDataPoint>;
 
@@ -265,6 +285,8 @@ module powerbi.extensibility.visual {
             this.xAxis = this.svg
                 .append('g')
                 .classed('xAxis', true);
+
+            this.initAverageLine();
 
             const helpLinkElement: Element = this.createHelpLinkElement();
             options.element.appendChild(helpLinkElement);
@@ -327,6 +349,8 @@ module powerbi.extensibility.visual {
 
             this.xAxis.attr('transform', 'translate(0, ' + height + ')')
                 .call(xAxis);
+
+            this.handleAverageLineUpdate(height, width, yScale);
 
             this.barSelection = this.barContainer
                 .selectAll('.bar')
@@ -504,6 +528,18 @@ module powerbi.extensibility.visual {
                         selector: null
                     });
                     break;
+                case 'averageLine':
+                    objectEnumeration.push({
+                        objectName: objectName,
+                        properties: {
+                            show: this.barChartSettings.averageLine.show,
+                            displayName: this.barChartSettings.averageLine.displayName,
+                            fill: this.barChartSettings.averageLine.fill,
+                            showDataLable: this.barChartSettings.averageLine.showDataLable
+                        },
+                        selector: null
+                    });
+                    break;
             };
 
             return objectEnumeration;
@@ -576,6 +612,75 @@ module powerbi.extensibility.visual {
             div.appendChild(p1);
 
             return div;
+        }
+
+        private getColorValue(color: Fill|string): string {
+            // Override color settings if in high contrast mode
+            if (this.host.colorPalette.isHighContrast) {
+                return this.host.colorPalette.foreground.value;
+            }
+
+            // If plain string, just return it
+            if (typeof(color) === 'string') {
+                return color
+            }
+            // Otherwise, extract string representation from Fill type object
+            return color.solid.color;
+        }
+
+        private initAverageLine() {
+            this.averageLine = this.svg
+                .append('g')
+                .classed('averageLine',true);
+
+            this.averageLine.append('line')
+                .attr('id','averageLine');
+
+            this.averageLine.append('text')
+                .attr('id','averageLineLabel');
+        }
+
+        private handleAverageLineUpdate(height:number, width:number, yScale: d3.scale.Linear<number,number>) {
+            let average = this.calculateAverage();
+            let fontSize = d3.min([height, width]) * BarChart.Config.xAxisFontMultiplier;
+            let chosenColor = this.getColorValue(this.barChartSettings.averageLine.fill);
+            // If there's no room to place lable above line, place it below
+            let lableYOffset = fontSize * ((yScale(average) > fontSize * 1.5)? -0.5 : 1.5);
+
+            this.averageLine
+                .style({
+                    "font-size": fontSize,
+                    "display": (this.barChartSettings.averageLine.show)? "initial" : "none",
+                })
+                .attr("transform", "translate(0, " + Math.round(yScale(average)) + ")")
+            this.averageLine.select("#averageLine")
+                .style({
+                    "stroke": chosenColor,
+                    "stroke-width": "3px",
+                    "stroke-dasharray": "6,6",
+                })
+                .attr({
+                    'x1': "0",
+                    'x2': "" + width
+                });
+            this.averageLine.select("#averageLineLabel")
+                .text("Average: "+average.toFixed(2))
+                .attr("transform", "translate(0, " + lableYOffset + ")")
+                .style("fill", this.barChartSettings.averageLine.showDataLable? chosenColor: "none");
+        }
+
+        private calculateAverage(): number {
+            if (this.barDataPoints.length === 0) {
+                return 0;
+            }
+
+            let total = 0;
+
+            this.barDataPoints.forEach((value:BarChartDataPoint) => {
+                total += <number>value.value;
+            })
+
+            return total/this.barDataPoints.length;
         }
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "declaration": true
   },
   "files": [
-    ".api/v2.3.0/PowerBI-visuals.d.ts",
+    ".api/v2.5.0/PowerBI-visuals.d.ts",
     "src/tooltipServiceWrapper.ts",
     "src/barChart.ts",
     "src/objectEnumerationUtility.ts",


### PR DESCRIPTION
This change includes:
***Preparations***
 1. Update visual to API v2.5.0
  2. Raise sample visual version to 2.5.0
Note for developers using this as reference: Step 2 isn't required, it is part of Sample Bar Chart's versioning convention.

**Analytics Pane Usage Example: Average Line**
  * New capability object "averageLine" with `"objectCategory": 2`
  * New `enumerateObjectInstances` entry for "averageLine"
  * Modified `BarChartSettings` and `visualTransform` entries to store "averageLine" settings
  * Graphics functions to calculate and draw an average line